### PR TITLE
tidyverse and SF experiments

### DIFF
--- a/vignettes/osm-tidyverse.Rmd
+++ b/vignettes/osm-tidyverse.Rmd
@@ -133,6 +133,12 @@ I don't think that polygon edges use transparency in the same way as lines.
 
 ```
 
+## No background - assignment to nearest group
+```{r,MultiSpatialGroupsClosest}
+
+
+```
+
 # High precision groups
 
 The spatial grouping procedures above have a two methods for defining group membership - 

--- a/vignettes/osm-tidyverse.Rmd
+++ b/vignettes/osm-tidyverse.Rmd
@@ -133,6 +133,22 @@ I don't think that polygon edges use transparency in the same way as lines.
 
 ```
 
+# High precision groups
+
+The spatial grouping procedures above have a two methods for defining group membership - 
+entirely inside or partly inside the polygon. Using simple features we should be able to
+go crazy and split objects into pieces. This will break the original osm structure, but
+could be useful in some cases.
+
+This test implementation is probably fragile, and causes warnings because there isn't an easy 
+way to divide up arbitrary attributes. Best not to call it with any more than osm ids in the
+input frame.
+
+```{r HighPrecGroupsA}
+
+```
+Note that the building have been split at group boundaries. Not sure if this is useful.
+
 # Surfaces
 
 

--- a/vignettes/osm-tidyverse.Rmd
+++ b/vignettes/osm-tidyverse.Rmd
@@ -1,0 +1,141 @@
+---
+title: "OSM maps using tidyverse approaches"
+author: "Richard Beare"
+date: "`r Sys.Date()`"
+output: 
+    html_document:
+        toc: true
+        toc_float: true
+        #number_sections: true
+        theme: flatly
+vignette: >
+  %\VignetteIndexEntry{Maps with Ocean}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+# Introduction
+
+This vignette explores the possibility of using a ggplot2-style approach to
+plotting maps using OpenStreetMap data fetched by `osmdata`. The `osmplotr` package
+already provides extensive display options using `ggplot2`, but some flexibility has been
+sacrificed to keep things simple for the user. The following facilities in `sf` and the
+development version of `ggplot2` make it interesting to test the idea of a "standard" ggplot2
+interface for osm data:
+
+1. `osmdata` presents osm objects in a simple features (sf) style data frame.
+1. a *geom_sf* for displaying simple features is available in the development version of ggplot2.
+1. extensive support for `dplyr`-like verbs for manipulating simple feature data frames in the `sf`
+package.
+
+How will the approach differ to `osmplotr`? The current approach applies spatial grouping and
+assignment of continuous values (surfaces) as a map is being produced - i.e. a base map, 
+osm data and grouping information are combined in a function to produce a map layer. 
+This means that many useful defaults can be provided. The "pure" ggplot2 way is to separate
+the assignment of groups from the display - the data frame containing osm data would be
+extended by adding new columns with grouping and surface data, which means that columns can
+be used in arbitrary mappings to display properties. For example, something that is difficult
+to do in the current framework, such as colour roads by group and apply transparency according
+to a continuous variable (such as speed limit), is easy to do (in principle) if the `ggplot2`
+framework is applied.
+
+The points above mean that testing this idea is a relatively low-cost exercise.
+
+There is a good chance that some capabilities in the existing system may not translate
+well, but it seems to be worth a try.
+
+# Dependencies
+
+```{r, eval=FALSE}
+devtools::install_github("tidyverse/ggplot2")
+```
+
+
+# Utility functions
+
+There are conflicts between `geom_sf` and `osm_basemap`, so we use a slightly modified versions
+here.
+```{r}
+library(knitr)
+read_chunk("osmtidy.R")
+```
+```{r osmbasemap, echo=FALSE}
+
+```
+
+I'll add other utilities as I'm playing around
+
+# Spatial Grouping
+
+Start without integrating anything much. Just demonstrate that it is possible. Lets assume that
+all the groups will be sf polygons.
+
+The current approach provides several definitions for inclusion in a spatial group -
+basically whether the object is entirely inside or crossing the region boundary. There is also the
+notion of distance to the nearest group when a background group isn't desired. I suspect these
+two notions should be separated for implementation using the sf tools.
+
+```{r SpatialGroupsFns, echo=FALSE, message=FALSE, warning=FALSE}
+
+```
+## One group
+
+```{r SpatialGroupsEx1, message=FALSE, warning=FALSE}
+
+```
+
+Straight away we can experiment with other views - e.g. transparency from building size!
+
+```{r SpatialGroupsEx2}
+
+```
+
+With some additional manipulation, we can keep the background constant grey.
+
+```{r SpatialGroupsEx3}
+
+```
+
+and we can completely change the appearance by fiddling with the calls to ggplot:
+
+```{r SpatialGroupsEx4}
+
+```
+
+Even though some of these calls look more complex, we have gained huge flexibility because
+the data frame is assembled outside the plotting routine, and ggplot allows us to change
+the mapping between visible elements and columns in the data frame.
+
+## Multiple groups.
+
+Now for a sanity check - does the code work with multiple foreground groups, and with
+the _overlap_ membership option:
+
+```{r MultiSpatialGroups}
+
+```
+
+```{r MultiSpatialGroupsEx1}
+
+```
+
+And now we can check just how cool the ability to change aesthetic mapping is:
+
+```{r MultiSpatialGroupsEx2}
+
+```
+
+In this last example the line thickness and transparency for the coloured groups is dependent
+on the building area, although transparency will only matter if there's something behind. Actually,
+I don't think that polygon edges use transparency in the same way as lines.
+
+```{r MultiSpatialGroupsEx3}
+
+```
+
+# Surfaces
+
+
+
+
+

--- a/vignettes/osmtidy.R
+++ b/vignettes/osmtidy.R
@@ -1,0 +1,199 @@
+## utility functions for osm-tidyverse
+## ---- osmbasemap ----
+library(osmplotr)
+check_bbox_arg <- function (bbox)
+{
+  if (missing (bbox))
+    stop ('bbox must be provided')
+  if (is (bbox, 'sf')) # sf obj submitted to osm_basemap
+  {
+    if (is (bbox$geometry, "sfc_LINESTRING") |
+        is (bbox$geometry, "sfc_POINT"))
+      xy <- do.call (rbind, bbox$geometry)
+    else if (is (bbox$geometry, "sfc_POLYGON"))
+      xy <- do.call (rbind, lapply (bbox$geometry, function (i) i [[1]]))
+    else if (is (bbox$geometry, "sfc_MULTIPOLYGON") |
+             is (bbox$geometry, "sfc_MULTILINESTRING"))
+      xy <- do.call (rbind, lapply (bbox$geometry,
+                                    function (i) i [[1]] [[1]]))
+    bbox <- t (apply (xy, 2, range))
+    rownames (bbox) <- c ("x", "y")
+    colnames (bbox) <- c ("min", "max")
+  }
+  if (!is.numeric (bbox))
+    stop ('bbox is not numeric')
+  if (length (bbox) < 4)
+    stop ('bbox must have length = 4')
+  if (length (bbox) > 4)
+  {
+    warning ('bbox has length > 4; only first 4 elements will be used')
+    bbox <- matrix (bbox [1:4], 2, 2)
+  }
+  
+  return (bbox)
+}
+
+osm_basemap2 <- function (bbox, structures, bg = 'gray20')
+{
+  # ---------------  sanity checks and warnings  ---------------
+  bbox <- check_bbox_arg (bbox)
+  if (!missing (structures))
+  {
+    check_structures_arg (structures)
+    bg <- structure$cols [which (structures$structure == 'background')]
+  }
+  #check_col_arg (bg)
+  if (length (bg) > 1)
+  {
+    warning ('bg has length > 1; only first element will be used')
+    bg <- bg [1]
+  }
+  # ---------------  end sanity checks and warnings  ---------------
+  
+  map_theme <- set_map_theme2 (bg = bg)
+  
+  lon <- lat <- NA
+  map <- ggplot2::ggplot () + map_theme +
+    ## This causes warnings from the sf geom.
+    #ggplot2::coord_map (xlim = range (bbox[1, ]),
+    #                    ylim = range (bbox[2, ])) +
+    ## don't need this as the sf geom deals with it.
+    # ggplot2::aes(x = lon, y = lat)
+    ggplot2::scale_x_continuous (expand = c(0, 0)) +
+    ggplot2::scale_y_continuous (expand = c(0, 0))
+  
+  return (map)
+}
+
+set_map_theme2 <- function (bg)
+{
+  theme <- ggplot2::theme_minimal ()
+  theme$panel.background <- ggplot2::element_rect (fill = bg, size = 0)
+  theme$line <- ggplot2::element_blank ()
+  theme$axis.text <- ggplot2::element_blank ()
+  theme$axis.title <- ggplot2::element_blank ()
+  theme$plot.margin <- ggplot2::margin (rep (ggplot2::unit (0, 'null'), 4))
+  theme$plot.margin <- ggplot2::margin (rep (ggplot2::unit (-0.5, 'line'), 4))
+  theme$legend.position <- 'none'
+  theme$axis.ticks.length <- ggplot2::unit (0, 'null')
+  
+  return (theme)
+}
+
+## ---- SpatialGroupsFns ----
+## better naming strategy needed
+#' Add a group column to an osm sf data frame
+#'
+#' @details Names from the region list are used to construct factor levels. A 
+#' background label is included. No checking to ensure regions don't overlap
+#' @param osmdata 
+#' @param regions a named list of sf polygons.
+#' @param colname the output column name
+#' 
+#' @return the input dataframe with an extra column named colname
+#' @export
+#'
+#' @examples
+add_osm_group_column <- function(osmdata, regions, 
+                                 membership=c("within", "overlaps"), 
+                                 colname="SpatialGroups", 
+                                 backgroundfactor="bg") {
+  membership <- match.arg(membership)
+  if (length(names(regions)) == 0) {
+    stop("Regions must be a named list")
+  }
+  rlist <- do.call(sf::st_sfc, list(regions, crs=sf::st_crs(osmdata)))
+  w <- sf::st_within(osmdata, rlist, sparse=FALSE)
+  if (membership == "overlaps") {
+    # also accepting objects that cross the boundary
+    w <- w | sf::st_overlaps(osmdata, rlist, sparse=FALSE)
+  }
+  bg <- !apply(w, MARGIN=1, any)
+  w <- cbind(bg, w)
+  colnames(w) <- c(backgroundfactor, names(regions))
+  
+  osmdata[[colname]] <- factor(w %*% (1:ncol(w)), labels=colnames(w))
+  return(osmdata)
+}
+
+## ---- SpatialGroupsEx1 ----
+library(osmplotr)
+library(ggplot2)
+library(dplyr)
+library(sf)
+data(london)
+dat_B <- rbind (london$dat_BNR, london$dat_BR)
+
+bbox <- get_bbox (c(-0.13, 51.51, -0.11, 51.52))
+
+pts <- cbind (c (-0.115, -0.125, -0.125, -0.115),
+              c (51.513, 51.513, 51.517, 51.517))
+
+#  Turn our corners into a polygon
+pts.sf <- sf::st_polygon(list(rbind(pts, pts[1,])))
+
+## generate the grouping column, and an area column for fun
+datB_g1 <- add_osm_group_column(dat_B, list(G1=pts.sf))
+datB_g1 <- mutate(datB_g1, AREA=st_area(geometry))
+
+lon.map1 <- osm_basemap2 (bbox = bbox,
+                          bg = 'gray20')
+lon.map1+geom_sf(data=datB_g1, aes(fill=SpatialGroups), colour=NA) + 
+  scale_fill_manual(values=c("gray40", "orange")) +
+  theme(panel.grid.major = element_line(colour = 'transparent')) 
+
+## ---- SpatialGroupsEx2 ----
+lon.map1+geom_sf(data=datB_g1, aes(fill=SpatialGroups, alpha=sqrt(as.numeric(AREA))), colour=NA) + 
+  scale_fill_manual(values=c("gray40", "orange")) +
+  theme(panel.grid.major = element_line(colour = 'transparent')) 
+
+## ---- SpatialGroupsEx3 ----
+## one liner for this
+datB_g1 <- mutate(datB_g1, fgArea = sqrt(as.numeric(AREA)))
+datB_g1 <- within(datB_g1, {
+  fgArea[SpatialGroups=="bg"] <- 1
+})
+
+lon.map1 + geom_sf(data=datB_g1, aes(fill=SpatialGroups, alpha=fgArea), colour=NA) + 
+  scale_fill_manual(values=c("gray40", "orange")) +
+  theme(panel.grid.major = element_line(colour = 'transparent')) 
+
+## ---- SpatialGroupsEx4 ----
+
+lon.map1 +
+  geom_sf(data=filter(datB_g1, SpatialGroups=="G1"), aes(alpha=fgArea), fill="orange", colour=NA) + 
+  geom_sf(data=filter(datB_g1, SpatialGroups=="bg"), fill="NA", colour="gray50", size=0.1) + 
+   theme(panel.grid.major = element_line(colour = 'transparent')) 
+
+## ---- MultiSpatialGroups ----
+pts2 <- cbind (c (-0.111, -0.1145, -0.1145, -0.111),
+               c (51.517, 51.517, 51.519, 51.519))
+pts2.sf <- sf::st_polygon(list(rbind(pts2, pts2[1,])))
+
+datB_g2 <- add_osm_group_column(dat_B, list(G1=pts.sf, g2=pts2.sf), membership="overlap")
+
+datB_g2 <- mutate(datB_g2, AREA=st_area(geometry), 
+                  fgArea=sqrt(as.numeric(AREA)))
+
+## ---- MultiSpatialGroupsEx1 ----
+
+lon.map2 <- osm_basemap2 (bbox = bbox,
+                          bg = 'gray20')
+lon.map2+geom_sf(data=datB_g2, aes(fill=SpatialGroups), colour=NA) + 
+  scale_fill_manual(values=c("gray40", "orange", "tomato")) +
+  theme(panel.grid.major = element_line(colour = 'transparent')) 
+## ---- MultiSpatialGroupsEx2 ----
+lon.map2 +
+  geom_sf(data=filter(datB_g2, SpatialGroups!="bg"), aes(alpha=fgArea, fill=SpatialGroups), colour=NA) + 
+  scale_fill_manual(values=c("orange", "tomato")) +
+  geom_sf(data=filter(datB_g2, SpatialGroups=="bg"), fill="NA", colour="gray60", size=0.1) + 
+  theme(panel.grid.major = element_line(colour = 'transparent')) 
+
+## ---- MultiSpatialGroupsEx3 ----
+lon.map2 +
+  scale_size(range=c(0.1, 1)) + 
+  geom_sf(data=filter(datB_g2, SpatialGroups!="bg"), 
+          aes(alpha=fgArea, colour=SpatialGroups, size=fgArea), fill=NA) + 
+  scale_colour_manual(values=c("orange", "tomato")) +
+  geom_sf(data=filter(datB_g2, SpatialGroups=="bg"), fill="NA", colour="gray60", size=0.1) + 
+  theme(panel.grid.major = element_line(colour = 'transparent')) 


### PR DESCRIPTION
Hi,
This isn't intended to be a ready-to-use pull request - more to let you have a look at what I've
been testing.

The original problem that lead me to think about this was using multiple mappings for single object
types - e.g. roads might have a group membership, corresponding to colour, and a continuous
measure, such as traffic load, speed limit, etc, that should be displayed as either size or
transparency. In principle an easy problem in ggplot2.

So, I've done some playing around with the more "traditional" ggplot2 approach. It turns out that the stars have aligned and most of the pieces are already in place. These are:

1. a `geom_sf` in the development version of ggplot2
1. lots of tidyverse verbs supported by the sf package, and the fact that sf uses special data frames.

There are two files in this PR - a Rmd and the supporting R code. No nice formatting or thorough testing, just a demo of ideas.

Notes - the ggplot2 support for sf is preliminary, and there are issues around where things like
xlim get set. These are different to how osmplotr is currently set up, and may be annoying.

sf gives lots of warnings about the assumptions it makes. I haven't attempted to turn them off.

Enjoy!